### PR TITLE
spelling fixes

### DIFF
--- a/src/Test/Hspec/Expectations.hs
+++ b/src/Test/Hspec/Expectations.hs
@@ -134,7 +134,7 @@ actual `shouldNotBe` notExpected = expectTrue ("not expected: " ++ show actual) 
 -- |
 -- @v \`shouldNotSatisfy\` p@ sets the expectation that @p v@ is @False@.
 with_loc(shouldNotSatisfy, (Show a) => a -> (a -> Bool) -> Expectation)
-v `shouldNotSatisfy` p = expectTrue ("predicate succeded on: " ++ show v) ((not . p) v)
+v `shouldNotSatisfy` p = expectTrue ("predicate succeeded on: " ++ show v) ((not . p) v)
 
 -- |
 -- @list \`shouldNotContain\` sublist@ sets the expectation that @sublist@ is not

--- a/test/Test/Hspec/ExpectationsSpec.hs
+++ b/test/Test/Hspec/ExpectationsSpec.hs
@@ -87,7 +87,7 @@ spec = do
       "bar" `shouldNotSatisfy` null
 
     it "fails if the value does satisfy predicate" $ do
-      ("" `shouldNotSatisfy` null) `shouldThrow` expectationFailed "predicate succeded on: \"\""
+      ("" `shouldNotSatisfy` null) `shouldThrow` expectationFailed "predicate succeeded on: \"\""
 
   describe "shouldNotReturn" $ do
     it "succeeds if arguments does not represent equal values" $ do


### PR DESCRIPTION
succeded ~> succeeded