### PR TITLE
Prettified shouldBe

### DIFF
--- a/hspec-expectations.cabal
+++ b/hspec-expectations.cabal
@@ -1,4 +1,4 @@
--- This file has been generated from package.yaml by hpack version 0.5.4.
+-- This file has been generated from package.yaml by hpack version 0.14.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -28,9 +28,11 @@ library
   build-depends:
       base == 4.*
     , HUnit
+    , pretty-show >= 1.6
   exposed-modules:
       Test.Hspec.Expectations
       Test.Hspec.Expectations.Contrib
   other-modules:
       Test.Hspec.Expectations.Matcher
+      Paths_hspec_expectations
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -15,6 +15,7 @@ ghc-options: -Wall
 dependencies:
   - base == 4.*
   - HUnit
+  - pretty-show >= 1.6
 
 library:
   source-dirs: src

--- a/src/Test/Hspec/Expectations.hs
+++ b/src/Test/Hspec/Expectations.hs
@@ -57,6 +57,7 @@ import           Data.List
 import           Control.Monad (unless)
 
 import           Test.Hspec.Expectations.Matcher
+import           Text.Show.Pretty (ppShow)
 
 #ifdef HAS_SOURCE_LOCATIONS
 
@@ -85,7 +86,10 @@ infix 1 `shouldNotBe`, `shouldNotSatisfy`, `shouldNotContain`, `shouldNotReturn`
 -- @actual \`shouldBe\` expected@ sets the expectation that @actual@ is equal
 -- to @expected@.
 with_loc(shouldBe, (Show a, Eq a) => a -> a -> Expectation)
-actual `shouldBe` expected = expectTrue ("expected: " ++ show expected ++ "\n but got: " ++ show actual) (actual == expected)
+actual `shouldBe` expected =
+  expectTrue msg (actual == expected)
+  where msg = "Expected:  " ++ ppShow expected ++ "\n" ++
+              "Actual: " ++ ppShow actual ++ "\n"
 
 -- |
 -- @v \`shouldSatisfy\` p@ sets the expectation that @p v@ is @True@.


### PR DESCRIPTION
Cf. https://github.com/yesodweb/yesod/pull/1259

Why?

Before:
![screenshot from 2016-08-18 14-19-20](https://cloud.githubusercontent.com/assets/320177/17787752/0ffa0652-6550-11e6-848b-8eccf5f1edbb.png)

After:
![screenshot from 2016-08-18 14-31-25](https://cloud.githubusercontent.com/assets/320177/17787830/76d9cb0a-6550-11e6-97a5-d7b703f97411.png)

Takes up more space, but is more readable. YMMV.

I'd like to figure out a good (SYB/Generics driven, ideally) diff solution for a future PR, suggestions to this end would be appreciated.
