### PR TITLE
Add orScream function for decorating failures

### DIFF
--- a/src/Test/Hspec/Expectations.hs
+++ b/src/Test/Hspec/Expectations.hs
@@ -25,6 +25,9 @@ module Test.Hspec.Expectations (
 -- * Expecting exceptions
 , shouldThrow
 
+-- * Decorating Expections
+, orScream
+
 -- ** Selecting exceptions
 , Selector
 
@@ -53,6 +56,7 @@ module Test.Hspec.Expectations (
 
 import qualified Test.HUnit
 import           Test.HUnit ((@?=))
+import           Test.HUnit.Lang (FailureReason(..), HUnitFailure(..), formatFailureReason)
 import           Control.Exception
 import           Data.Typeable
 import           Data.List
@@ -178,6 +182,20 @@ action `shouldThrow` p = do
       where
         instanceOf :: Selector a -> a
         instanceOf _ = error "Test.Hspec.Expectations.shouldThrow: broken Typeable instance"
+
+-- |
+-- Preppend a message to an @'HUnitFailure'@
+--
+-- @
+-- myValue `shouldBe` myExpectation `orScream` "Oh GAWD no!"
+-- @
+--
+orScream :: Expectation -> String -> Expectation
+orScream action message =
+  action `catch` \(HUnitFailure l r) ->
+    throwIO . HUnitFailure l . Reason $ message ++ "\n\n" ++ formatFailureReason r
+
+infix 0 `orScream`
 
 anyException :: Selector SomeException
 anyException = const True

--- a/src/Test/Hspec/Expectations.hs
+++ b/src/Test/Hspec/Expectations.hs
@@ -184,7 +184,8 @@ action `shouldThrow` p = do
         instanceOf _ = error "Test.Hspec.Expectations.shouldThrow: broken Typeable instance"
 
 -- |
--- Preppend a message to an @'HUnitFailure'@
+-- Decorate an @'Expectation'@ with a message. The @'String'@ is prepended to
+-- failure messages.
 --
 -- @
 -- myValue `shouldBe` myExpectation `orScream` "Oh GAWD no!"

--- a/test/Test/Hspec/ExpectationsSpec.hs
+++ b/test/Test/Hspec/ExpectationsSpec.hs
@@ -112,3 +112,8 @@ spec = do
 
     it "fails, if an exception of a specific type is required, but no exception is thrown" $ do
       (return () `shouldThrow` anyErrorCall) `shouldThrow` expectationFailed (Reason "did not get expected exception: ErrorCall")
+
+  describe "orScream" $ do
+    it "prepends a message" $ do
+      ("foo" `shouldBe` "bar" `orScream` "Oh no!")
+        `shouldThrow` expectationFailed (Reason "Oh no!\n\nexpected: \"bar\"\n but got: \"foo\"")


### PR DESCRIPTION
This function is a smaller combinator for decorating failures by
prepending them with a message.  This is helpful when you need to
provide more context on a specific expectation with an `it` block. It can
also be used to dissambiguate failures when looking for an expectation.

The originally implementation was:
```
orScream :: MonadCatch m => m a -> String -> m a
orScream action message =
  action `catch` \(HUnitFailure l r) ->
    throwM . HUnitFailure l . Reason $ message ++ "\n\n" ++ formatFailureReason r
```