### PR TITLE
Add the annotate function

### DIFF
--- a/.ghci
+++ b/.ghci
@@ -1,2 +1,1 @@
-:set -isrc -itest -idist/build/autogen -pgmL markdown-unlit -optL haskell+literate
-:set -optP-includedist/build/autogen/cabal_macros.h
+:set -isrc -itest -pgmL markdown-unlit -optL haskell+literate

--- a/hspec-expectations.cabal
+++ b/hspec-expectations.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:             hspec-expectations
-version:          0.8.2
+version:          0.8.3
 synopsis:         Catchy combinators for HUnit
 description:      Catchy combinators for HUnit: <https://github.com/hspec/hspec-expectations#readme>
 bug-reports:      https://github.com/hspec/hspec-expectations/issues
@@ -51,6 +51,8 @@ test-suite spec
     , call-stack
     , nanospec
   other-modules:
+      Helper
+      Test.Hspec.Expectations.ContribSpec
       Test.Hspec.Expectations.MatcherSpec
       Test.Hspec.ExpectationsSpec
       Test.Hspec.Expectations

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: hspec-expectations
-version: 0.8.2
+version: 0.8.3
 synopsis: Catchy combinators for HUnit
 description: "Catchy combinators for HUnit: <https://github.com/hspec/hspec-expectations#readme>"
 license: MIT

--- a/src/Test/Hspec/Expectations/Contrib.hs
+++ b/src/Test/Hspec/Expectations/Contrib.hs
@@ -7,8 +7,13 @@ module Test.Hspec.Expectations.Contrib (
 -- | (useful in combination with `shouldSatisfy`)
   isLeft
 , isRight
+
+-- * Annotating expectations
+, annotate
 ) where
 
+import Control.Exception
+import Test.HUnit.Lang (HUnitFailure(..), FailureReason(..))
 
 #if MIN_VERSION_base(4,7,0)
 import Data.Either
@@ -24,3 +29,32 @@ isRight :: Either a b -> Bool
 isRight (Left  _) = False
 isRight (Right _) = True
 #endif
+
+-- |
+-- If you have a test case that has multiple assertions, you can use the
+-- 'annotate' function to provide a string message that will be attached to
+-- the 'Expectation'.
+--
+-- @
+-- describe "annotate" $ do
+--   it "adds the message" $ do
+--     annotate "obvious falsehood" $ do
+--       True `shouldBe` False
+--
+-- ========>
+--
+-- 1) annotate, adds the message
+--       obvious falsehood
+--       expected: False
+--        but got: True
+-- @
+--
+-- @since 0.8.3
+annotate :: String -> IO a -> IO a
+annotate message = handle $ \ (HUnitFailure loc reason) -> throwIO . HUnitFailure loc $ case reason of
+  Reason err -> Reason $ addMessage err
+  ExpectedButGot err expected got -> ExpectedButGot (Just $ maybe message addMessage err) expected got
+  where
+    addMessage err
+      | null err = message
+      | otherwise = message ++ "\n" ++ err

--- a/test/Helper.hs
+++ b/test/Helper.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE FlexibleContexts #-}
+
+module Helper where
+
+import           Test.HUnit.Lang
+import           Data.CallStack
+
+-- note: this function expects the callstacks to have identical line
+-- numbers, so you need to be careful to call expectationFailed on the same
+-- line that you throw any exceptions
+expectationFailed :: HasCallStack => FailureReason -> HUnitFailure -> Bool
+expectationFailed msg (HUnitFailure l m) = m == msg && (fmap setColumn l) == (fmap setColumn location)
+  where
+    location = case reverse callStack of
+      [] -> Nothing
+      (_, loc) : _ -> Just loc
+    location :: Maybe SrcLoc
+
+    setColumn loc_ = loc_{srcLocStartCol = 0, srcLocEndCol = 0}

--- a/test/Test/Hspec/Expectations/ContribSpec.hs
+++ b/test/Test/Hspec/Expectations/ContribSpec.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+module Test.Hspec.Expectations.ContribSpec (spec) where
+
+import           Helper
+
+import           Test.HUnit.Lang
+import           Test.Hspec (Spec, describe, it)
+
+import           Test.Hspec.Expectations
+import           Test.Hspec.Expectations.Contrib
+
+spec :: Spec
+spec = do
+  describe "annotate" $ do
+    it "does not affect the running of a successful test" $ do
+      annotate "obviously correct" $
+        True `shouldBe` True
+
+    it "provides a message on expectation failure" $ do
+      (annotate "obvious falsehood" $ True `shouldBe` False) `shouldThrow` expectationFailed (ExpectedButGot (Just "obvious falsehood") (show False) (show True))
+
+    it "nests messages using newlines" $ do
+      let msg0 = "obvious falsehood"
+          msg1 = "welp"
+          msgs = msg0 ++ "\n" ++ msg1
+      (annotate msg0 $ annotate msg1 $ True `shouldBe` False) `shouldThrow` expectationFailed (ExpectedButGot (Just msgs) (show False) (show True))
+
+    it "appends messages to Reason" $ do
+      (annotate "welp" $ True `shouldSatisfy` (== False)) `shouldThrow` expectationFailed (Reason "welp\npredicate failed on: True")

--- a/test/Test/Hspec/ExpectationsSpec.hs
+++ b/test/Test/Hspec/ExpectationsSpec.hs
@@ -2,22 +2,13 @@
 {-# LANGUAGE FlexibleContexts #-}
 module Test.Hspec.ExpectationsSpec (spec) where
 
+import           Helper
+
 import           Control.Exception
 import           Test.HUnit.Lang
 import           Test.Hspec (Spec, describe, it)
 
-import           Test.Hspec.Expectations hiding (HasCallStack)
-import           Data.CallStack
-
-expectationFailed :: HasCallStack => FailureReason -> HUnitFailure -> Bool
-expectationFailed msg (HUnitFailure l m) = m == msg && (fmap setColumn l) == (fmap setColumn location)
-  where
-    location = case reverse callStack of
-      [] -> Nothing
-      (_, loc) : _ -> Just loc
-    location :: Maybe SrcLoc
-
-    setColumn loc_ = loc_{srcLocStartCol = 0, srcLocEndCol = 0}
+import           Test.Hspec.Expectations
 
 spec :: Spec
 spec = do


### PR DESCRIPTION
This PR adds a function `annotate` that can be used to annotate an `Expectation` with a message.

At work, we have a number of tests that do work against the database. Due to the expensive nature of these tests, we want to get as many assertions in as possible per case. It can be difficult to figure out at-a-glance why an expectation failed, so we've developed this function to make it easier.