### PR TITLE
Update supported GHC list

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,8 +16,11 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-latest # https://launchpad.net/~hvr/+archive/ubuntu/ghc?field.series_filter=xenial
+          - ubuntu-18.04 # latest # https://launchpad.net/~hvr/+archive/ubuntu/ghc?field.series_filter=xenial
         ghc:
+          - '7.4.2'
+          - '7.6.3'
+          - '7.8.4'
           - '7.10'
           - '8.0'
           - '8.2'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,8 @@ jobs:
           - os: windows-latest
             ghc: latest
     steps:
+      - name: Install libnuma (avoid a problem with ghc 8.4 somehow)
+        run: sudo apt-get install -y libnuma-dev
       - uses: actions/checkout@v2
       - uses: haskell/actions/setup@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-16.04 # https://launchpad.net/~hvr/+archive/ubuntu/ghc?field.series_filter=xenial
+          - ubuntu-latest # https://launchpad.net/~hvr/+archive/ubuntu/ghc?field.series_filter=xenial
         ghc:
           - '7.10'
           - '8.0'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,9 +18,6 @@ jobs:
         os:
           - ubuntu-16.04 # https://launchpad.net/~hvr/+archive/ubuntu/ghc?field.series_filter=xenial
         ghc:
-          - '7.4.2'
-          - '7.6.3'
-          - '7.8.4'
           - '7.10'
           - '8.0'
           - '8.2'
@@ -28,6 +25,8 @@ jobs:
           - '8.6'
           - '8.8'
           - '8.10'
+          - '9.0'
+          - '9.2'
         include:
           - os: macos-latest
             ghc: latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
             ghc: latest
     steps:
       - name: Install libnuma (avoid a problem with ghc 8.4 somehow)
-        if: {{ matrix.os == 'ubuntu-18.04' }}
+        if: ${{ matrix.os == 'ubuntu-18.04' }}
         run: sudo apt-get install -y libnuma-dev
       - uses: actions/checkout@v2
       - uses: haskell/actions/setup@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,7 @@ jobs:
             ghc: latest
     steps:
       - name: Install libnuma (avoid a problem with ghc 8.4 somehow)
+        if: {{ matrix.os == 'ubuntu-18.04' }}
         run: sudo apt-get install -y libnuma-dev
       - uses: actions/checkout@v2
       - uses: haskell/actions/setup@v1

--- a/package.yaml
+++ b/package.yaml
@@ -13,7 +13,7 @@ github: hspec/hspec-expectations
 ghc-options: -Wall
 
 dependencies:
-  - base == 4.*
+  - base >= 4.8 && < 4.17
   - call-stack
 
 library:


### PR DESCRIPTION
This PR drops GHC < 7.10 support and adds CI for GHC 9.0 and 9.2

According to the [State of Haskell 2021 Survey](https://taylor.fausak.me/2021/11/16/haskell-survey-results/), fewer than 1% of respondents were using GHC < 8.2.

GHC 7.10 was released seven years ago, which is a pretty huge maintenance window.

It's difficult to even install or build things with GHCs that old. I was able to get the repo building with `stack` and `--resolver lts-6`, but prior resolvers had problems with `Cabal` and needed older `stack` versions. `ghcup` doesn't provide anything older than 7.10.3, and I wasn't even able to get that to build the library on my machine.